### PR TITLE
Add collapsible tree with scrolling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,8 +7,7 @@
   <script src="https://unpkg.com/d3@7.8.5/dist/d3.min.js"></script>
   <style>
     body { font-family: sans-serif; }
-    .node circle { fill: #fff; stroke: steelblue; stroke-width: 3px; }
-    .node text { font: 12px sans-serif; }
+    #chart { overflow-x: auto; }
     .link { fill: none; stroke: #ccc; stroke-width: 2px; }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- allow horizontal scroll for the chart area
- draw each node as a rectangle with name inside
- support collapsing and expanding nodes on click

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68668974ee74832bbd8304af995955c1