### PR TITLE
Improve tree layout spacing and scrolling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,11 @@
   <script src="https://unpkg.com/d3@7.8.5/dist/d3.min.js"></script>
   <style>
     body { font-family: sans-serif; }
-    #chart { overflow-x: auto; }
+    #chart {
+      overflow-x: auto;
+      overflow-y: hidden;
+      width: 100%;
+    }
     .link { fill: none; stroke: #ccc; stroke-width: 2px; }
   </style>
 </head>

--- a/public/script.js
+++ b/public/script.js
@@ -43,7 +43,7 @@ function drawTree(data) {
   const rectHeight = 20;
   const tree = d3.tree()
     .nodeSize([dx, dy])
-    .separation((a, b) => (a.parent === b.parent ? 1.5 : 2.5));
+    .separation((a, b) => (a.parent === b.parent ? 2 : 3));
   const diagonal = d3.linkVertical().x(d => d.x).y(d => d.y);
 
   const root = d3.hierarchy(data);
@@ -75,7 +75,10 @@ function drawTree(data) {
 
     const width = right.x - left.x + margin.left + margin.right + rectWidth;
     const height = bottom.y - top.y + margin.top + margin.bottom + rectHeight;
-    svg.attr('viewBox', [0, 0, width, height]);
+    svg
+      .attr('viewBox', [0, 0, width, height])
+      .attr('width', width)
+      .attr('height', height);
 
     const offsetX = margin.left + (width - margin.left - margin.right) / 2 - root.x;
     g.attr('transform', `translate(${offsetX},${margin.top})`);


### PR DESCRIPTION
## Summary
- widen spacing between nodes in the D3 layout
- size SVG using calculated width/height so that horizontal scrolling works
- set chart container to support horizontal scrolling

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6866949eda5c832bb4fe85723dd5a43f