### PR TITLE
Fix spouse node overlap

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -168,7 +168,7 @@ function drawTree(data) {
 
     const spouseEnter = nodeEnter.filter(d => d.data.spouse).append('g')
       .attr('class', 'spouse')
-      .attr('transform', `translate(${rectWidth / 2 + spouseGap},0)`);
+      .attr('transform', `translate(${rectWidth + spouseGap},0)`);
 
     spouseEnter.append('rect')
       .attr('x', -rectWidth / 2)


### PR DESCRIPTION
## Summary
- ensure spouse node is shifted to the right of a person's node

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6867dd7193f8832b969166656e7e9082