### PR TITLE
Adjust node border color by gender

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -160,7 +160,7 @@ function drawTree(data) {
       .attr('width', rectWidth)
       .attr('height', rectHeight)
       .attr('fill', '#fff')
-      .attr('stroke', 'steelblue');
+      .attr('stroke', d => d.data.gender === 2 ? 'pink' : 'steelblue');
 
     nodeEnter.append('text')
       .attr('dy', '0.31em')
@@ -177,7 +177,7 @@ function drawTree(data) {
       .attr('width', rectWidth)
       .attr('height', rectHeight)
       .attr('fill', '#fff')
-      .attr('stroke', 'pink');
+      .attr('stroke', d => d.data.spouse.gender === 2 ? 'pink' : 'steelblue');
 
     spouseEnter.append('text')
       .attr('dy', '0.31em')


### PR DESCRIPTION
## Summary
- nodes use pink borders only for females
- spouse nodes also use gender-based border colors

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6867dfdd2214832b8a8dcffb2b9cd11a