### PR TITLE
Add zoom capability and adjust scroll handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,12 +6,21 @@
   <title>Family Tree</title>
   <script src="https://unpkg.com/d3@7.8.5/dist/d3.min.js"></script>
   <style>
-    body { font-family: sans-serif; }
-    #chart {
+    body {
+      font-family: sans-serif;
+      margin: 0;
+      /* Allow the page itself to scroll horizontally so the scrollbar sits at
+         the bottom of the window */
       overflow-x: auto;
-      overflow-y: hidden;
-      width: 100%;
     }
+    #chart {
+      /* Let the chart grow wider than the viewport and rely on the body for
+         scrolling */
+      overflow: visible;
+      width: fit-content;
+    }
+    /* Disable browser gestures that interfere with pinch zoom */
+    #chart svg { touch-action: none; }
     .link { fill: none; stroke: #ccc; stroke-width: 2px; }
   </style>
 </head>

--- a/script.js
+++ b/script.js
@@ -122,7 +122,18 @@ function drawTree(data) {
     .style('user-select', 'none')
     .style('margin-bottom', '20px');
 
-  const g = svg.append('g');
+  // Wrap the actual drawing group in a zoom layer so zooming doesn't
+  // interfere with the layout transforms applied by update()
+  const zoomLayer = svg.append('g');
+  const g = zoomLayer.append('g');
+
+  // Enable wheel/pinch zooming
+  const zoom = d3.zoom()
+    .scaleExtent([0.5, 2])
+    .on('zoom', (event) => {
+      zoomLayer.attr('transform', event.transform);
+    });
+  svg.call(zoom);
 
   function update(source) {
     tree(root);


### PR DESCRIPTION
## Summary
- move horizontal scrolling to the body so the scrollbar sits at the bottom of the page
- enable zooming via mouse wheel or pinch

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686dc37c46bc832bb449f0caa1610c11