### PR TITLE
Adjust chart dimensions for taller layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,8 +23,8 @@
        keep the SVG the same size as the browser viewport */
     #chart svg {
       touch-action: none;
-      height: 100vh;
-      width: 100vw;
+      height: 120vh;
+      width: 60vw;
     }
     .link { fill: none; stroke: #ccc; stroke-width: 2px; }
   </style>

--- a/script.js
+++ b/script.js
@@ -117,8 +117,8 @@ function drawTree(data) {
     d._children = d.children;
   });
 
-  const viewWidth = window.innerWidth;
-  const viewHeight = window.innerHeight;
+  const viewWidth = window.innerWidth * 0.6;
+  const viewHeight = window.innerHeight * 1.2;
 
   const svg = d3.select('#chart').append('svg')
     // slightly larger font to match bigger nodes
@@ -128,9 +128,9 @@ function drawTree(data) {
     .attr('viewBox', [0, 0, viewWidth, viewHeight])
     .attr('width', viewWidth)
     .attr('height', viewHeight)
-    // Keep the SVG the same size as the viewport
-    .style('height', '100vh')
-    .style('width', '100vw');
+    // Keep the SVG dimensions consistent with the CSS sizing
+    .style('height', '120vh')
+    .style('width', '60vw');
 
   // Wrap the actual drawing group in a zoom layer so zooming doesn't
   // interfere with the layout transforms applied by update()


### PR DESCRIPTION
## Summary
- tweak chart CSS to make the visualization taller and narrower
- scale SVG size in `script.js` to match the new dimensions

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_686e6e36e5bc832bb286f077fc088f9a