### PR TITLE
Support root id parameter in URL

### DIFF
--- a/script.js
+++ b/script.js
@@ -3,6 +3,17 @@ let currentRoot;
 
 // The family data is provided by familyData.js as a global variable.
 const data = window.familyData;
+// Allow overriding the root member via a `root_id` query parameter
+if (data) {
+  const params = new URLSearchParams(window.location.search);
+  const paramRoot = params.get('root_id');
+  if (paramRoot !== null) {
+    const parsed = parseInt(paramRoot, 10);
+    if (!Number.isNaN(parsed)) {
+      data.root = parsed;
+    }
+  }
+}
 if (data) {
   const root = buildHierarchy(data);
   if (root) {


### PR DESCRIPTION
## Summary
- allow overriding the tree root via `root_id` URL query parameter

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e793b2e28832b97de84f9b725d7cc