### PR TITLE
Implement node double-click reload

### DIFF
--- a/script.js
+++ b/script.js
@@ -210,6 +210,10 @@ function drawTree(data) {
           d._children = null;
         }
         update(d);
+      })
+      .on('dblclick', (event, d) => {
+        event.stopPropagation();
+        reloadWithRootId(d.data.id);
       });
 
     nodeEnter.append('rect')
@@ -231,7 +235,18 @@ function drawTree(data) {
       .style('cursor', 'pointer')
       .on('click', (event, d) => {
         event.stopPropagation();
-        expandRootFromSpouse(d.data.spouse);
+        if (d.children) {
+          d._children = d.children;
+          d.children = null;
+        } else {
+          d.children = d._children;
+          d._children = null;
+        }
+        update(d);
+      })
+      .on('dblclick', (event, d) => {
+        event.stopPropagation();
+        reloadWithRootId(d.data.spouse.id);
       });
 
     spouseEnter.append('rect')
@@ -302,4 +317,10 @@ function expandRootFromSpouse(spouse) {
   currentRoot = grand || parent || spouse;
   d3.select('#chart').selectAll('svg').remove();
   drawTree(currentRoot);
+}
+
+function reloadWithRootId(id) {
+  const params = new URLSearchParams(window.location.search);
+  params.set('root_id', id);
+  window.location.search = `?${params.toString()}`;
 }


### PR DESCRIPTION
## Summary
- handle single and double click on nodes
- toggle spouse node children on single click
- reload page with new root on double-click
- utility to update URL with root id

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_68711ff9a758832bb08180e44f5d2907