### PR TITLE
Modify up arrow navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ tree is rendered on the page.
 
 - **Single click** a member or spouse to toggle display of their children.
 - **Double click** a member or spouse to reload the tree using that person as the new root.
+- **Click the up arrow** above the root node to reload the tree using its parent when available.
 - Single-click actions wait a short delay so that a double click will cancel them.
 
 ## Customizing Data

--- a/script.js
+++ b/script.js
@@ -314,8 +314,7 @@ function expandRootUp() {
   if (!currentRoot) return;
   const parent = idMap.get(currentRoot.parent_id);
   if (!parent) return;
-  const grand = idMap.get(parent.parent_id);
-  currentRoot = grand || parent;
+  currentRoot = parent;
   d3.select('#chart').selectAll('svg').remove();
   drawTree(currentRoot);
 }


### PR DESCRIPTION
## Summary
- update README to document up-arrow behavior
- stop going up two levels when using the root node's up arrow

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_6871f5591288832b86f94b3874ae1ae6