### PR TITLE
Fix double tap interaction on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ tree is rendered on the page.
 ## Interactions
 
 - **Single click** a member or spouse to toggle display of their children.
-- **Double click** a member or spouse to reload the tree using that person as the new root.
+- **Double click** (or double tap on touch screens) a member or spouse to reload the tree using that person as the new root.
 - **Click the up arrow** above the root node to reload the tree using its parent when available.
 - Single-click actions wait a short delay so that a double click will cancel them.
 

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
   <title>Family Tree</title>
   <script src="https://unpkg.com/d3@7.8.5/dist/d3.min.js"></script>
   <style>

--- a/script.js
+++ b/script.js
@@ -2,6 +2,25 @@ const CLICK_DELAY = 250; // ms delay for distinguishing single vs double click
 let idMap;
 let currentRoot;
 let clickTimer = null;
+let lastTouchTime = 0;
+
+function handleTouch(event, single, dbl) {
+  event.preventDefault();
+  event.stopPropagation();
+  const now = Date.now();
+  if (now - lastTouchTime <= CLICK_DELAY) {
+    clearTimeout(clickTimer);
+    lastTouchTime = 0;
+    dbl();
+  } else {
+    clearTimeout(clickTimer);
+    lastTouchTime = now;
+    clickTimer = setTimeout(() => {
+      single();
+      lastTouchTime = 0;
+    }, CLICK_DELAY);
+  }
+}
 
 // The family data is provided by familyData.js as a global variable.
 const data = window.familyData;
@@ -203,6 +222,20 @@ function drawTree(data) {
       .attr('class', 'node')
       .attr('transform', () => `translate(${source.x0},${source.y0})`)
       .style('cursor', 'pointer')
+      .on('touchstart', (event, d) => {
+        handleTouch(event, () => {
+          if (d.children) {
+            d._children = d.children;
+            d.children = null;
+          } else {
+            d.children = d._children;
+            d._children = null;
+          }
+          update(d);
+        }, () => {
+          reloadWithRootId(d.data.id);
+        });
+      })
       .on('click', (event, d) => {
         clearTimeout(clickTimer);
         clickTimer = setTimeout(() => {
@@ -239,6 +272,20 @@ function drawTree(data) {
       .attr('class', 'spouse')
       .attr('transform', `translate(${rectWidth + spouseGap},0)`)
       .style('cursor', 'pointer')
+      .on('touchstart', (event, d) => {
+        handleTouch(event, () => {
+          if (d.children) {
+            d._children = d.children;
+            d.children = null;
+          } else {
+            d.children = d._children;
+            d._children = null;
+          }
+          update(d);
+        }, () => {
+          reloadWithRootId(d.data.spouse.id);
+        });
+      })
       .on('click', (event, d) => {
         event.stopPropagation();
         clearTimeout(clickTimer);


### PR DESCRIPTION
## Summary
- disable browser double tap zoom via viewport setting
- handle touch events so double tapping nodes/spouses loads them as root
- document double tap ability

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_6871fe2b8f78832b9e5251f96ea4bc44